### PR TITLE
eslintrc 미적용 이슈 해결 - parserOptions의 project 속성을 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,11 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended"
   ],
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": "latest"
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "project": "./tsconfig.json"
   },
   "rules": {
     "react/react-in-jsx-scope": "off"

--- a/src/@styles/colors.ts
+++ b/src/@styles/colors.ts
@@ -1,4 +1,4 @@
-export const COLORS = {
+const COLORS = {
   GREY: {
     100: "#181818",
     95: "#121212",
@@ -60,3 +60,5 @@ export const COLORS = {
     30: "#EEEBFF",
   },
 } as const;
+
+export default COLORS;

--- a/src/@styles/theme.ts
+++ b/src/@styles/theme.ts
@@ -1,4 +1,4 @@
-import { COLORS } from "@src/@styles/colors";
+import COLORS from "@src/@styles/colors";
 import { FONT_SIZE } from "@src/@styles/fontSize";
 
 export const LIGHT_MODE_THEME = {
@@ -33,3 +33,5 @@ export const LIGHT_MODE_THEME = {
     CAPTION: FONT_SIZE["10px"],
   },
 } as const;
+
+export const DARK_MODE_THEME = {};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,10 @@ import { LIGHT_MODE_THEME } from "@src/@styles/theme";
 
 function App() {
   return (
-    <>
-      <ThemeProvider theme={LIGHT_MODE_THEME}>
-        <GlobalStyle />
-        <div>hello world!</div>
-      </ThemeProvider>
-    </>
+    <ThemeProvider theme={LIGHT_MODE_THEME}>
+      <GlobalStyle />
+      <div>hello world!</div>
+    </ThemeProvider>
   );
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const path = require("path");


### PR DESCRIPTION
## 작업 내용

.eslintrc.json - parserOptions의 project 속성을 추가했습니다.

<br><br>

## 참고 사항

eslint에서 TypeScript 코드를 linting 하기 위해 tsconfig.json 파일을 사용합니다. 이때, project 속성을 설정하면, eslint가 해당 프로젝트 설정 파일을 이용하여 TypeScript 파일을 검사합니다.

<br><br>

## 관련 이슈

- #이슈번호

<br><br>
