### PR TITLE
DefaultTheme 타입 지정 외

### DIFF
--- a/src/@styles/GlobalStyle.tsx
+++ b/src/@styles/GlobalStyle.tsx
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from "styled-components";
+import { createGlobalStyle, css } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
   /* @import url(https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@1.0/nanumsquare.css); */
@@ -38,6 +38,9 @@ const GlobalStyle = createGlobalStyle`
   }
   body {
     line-height: 1;
+    ${({ theme }) => css`
+      background-color: ${theme.COLOR.BACKGROUND.DEFAULT};
+    `}
   }
   menu, ol, ul {
     list-style: none;
@@ -62,7 +65,9 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: border-box;
     font-family:  'Spoqa Han Sans Neo',"Pretendard Variable", Pretendard, "Noto Sans KR", sans-serif;
     letter-spacing: -0.02em;
-    color: #414141;
+    ${({ theme }) => css`
+      color: ${theme.COLOR.TEXT.DEFAULT};
+    `}
   }
 `;
 

--- a/src/@styles/fontSize.ts
+++ b/src/@styles/fontSize.ts
@@ -1,4 +1,4 @@
-export const FONT_SIZE = {
+const FONT_SIZE = {
   "34px": "2.125rem",
   "20px": "1.25rem",
   "18px": "1.125rem",
@@ -6,3 +6,5 @@ export const FONT_SIZE = {
   "12px": "0.75rem",
   "10px": "0.625rem",
 } as const;
+
+export default FONT_SIZE;

--- a/src/@styles/theme.ts
+++ b/src/@styles/theme.ts
@@ -1,7 +1,9 @@
-import COLORS from "@src/@styles/colors";
-import { FONT_SIZE } from "@src/@styles/fontSize";
+import { DefaultTheme } from "styled-components";
 
-export const LIGHT_MODE_THEME = {
+import COLORS from "@src/@styles/colors";
+import FONT_SIZE from "@src/@styles/fontSize";
+
+export const LIGHT_MODE_THEME: DefaultTheme = {
   COLOR: {
     PRIMARY: COLORS.BLUE[60],
     SECONDARY: COLORS.GREY[80],

--- a/src/@types/style.d.ts
+++ b/src/@types/style.d.ts
@@ -1,0 +1,36 @@
+import "styled-components";
+
+declare module "styled-components" {
+  export interface DefaultTheme {
+    COLOR: {
+      PRIMARY: string;
+      SECONDARY: string;
+      TEXT: {
+        DEFAULT: string;
+        DISABLED: string;
+        PLACEHOLDER: string;
+        LIGHT_BLUE: string;
+        WHITE: string;
+      };
+      BACKGROUND: {
+        DEFAULT: string;
+        SECONDARY: string;
+        TERTIARY: string;
+      };
+      CONTAINER: {
+        PRIMARY: string;
+        DEFAULT: string;
+      };
+      BORDER: string;
+    };
+    FONT_SIZE: {
+      TITLE: string;
+      SUBTITLE: string;
+      X_LARGE_BODY: string;
+      LARGE_BODY: string;
+      BODY: string;
+      PLACEHOLDER: string;
+      CAPTION: string;
+    };
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,10 @@ module.exports = {
   },
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
+    alias: {
+      "@src": path.resolve(__dirname, "src"),
+      "@public": path.resolve(__dirname, "public"),
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
## 작업 내용

1. src/@types/style.d.ts 파일을 만들어서 DefaultTheme의 인터페이스를 지정해줬습니다.
2. 웹팩 설정에서 @src와 같은 path를 인식 할 수 있게 해주었습니다.

<br><br>

## 참고 사항

```tsx
${({ theme }) => css`
  color: ${theme.COLOR.TEXT.DEFAULT};
`}
```
스타일드컴포넌트 안에서 위와 같이 theme을 불러오면 사용할 수 있고 타입도 인식합니다.
<img width="398" alt="image" src="https://user-images.githubusercontent.com/102677317/229731581-23cdc0cd-8cc8-43cf-8f53-9a370219d358.png">


<br><br>

## 관련 이슈

- #2 

<br><br>
